### PR TITLE
[Config/#51] API 문서 항상 접근 가능하게 허용

### DIFF
--- a/src/main/java/life/inha/icemarket/config/SecurityConfig.java
+++ b/src/main/java/life/inha/icemarket/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig{
                 .csrf().disable()
                 .formLogin().disable()
                 .authorizeRequests()
+                .antMatchers("/v3/api-docs/**", "/swagger*/**").permitAll()
                 .antMatchers("/login").permitAll()
                 .antMatchers("/findpw").hasRole("USER")
                 .antMatchers("/resetpw").permitAll()


### PR DESCRIPTION
Spring Security로 인해 프론트엔드 팀에서 API 문서가 안 보이는 이슈 발생

-> 로그인 토큰(JWT) 없이 API 문서 항상 접근 가능하게 허용

