### PR TITLE
[Feature/#56] 이메일 인증방식 변경

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -6,6 +6,7 @@ CREATE TABLE users (
     nickname        VARCHAR(10)  UNIQUE,
     role            VARCHAR(10)  NOT NULL,
     status          VARCHAR(10)  NOT NULL,
+    emailconfirmkey VARCHAR(10),
     created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     deleted_at      TIMESTAMP

--- a/src/main/java/life/inha/icemarket/controller/AuthApi.java
+++ b/src/main/java/life/inha/icemarket/controller/AuthApi.java
@@ -1,0 +1,28 @@
+package life.inha.icemarket.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import life.inha.icemarket.config.swagger.ApiDocumentResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * SwaggerUi Api문서에 로그인 화면을 등록하기 위함입니다.
+ */
+@Tag(name="Login", description = "로그인 API")
+@Controller
+public class AuthApi {
+    @Operation(description = "로그인 페이지 - email과 비밀번호를 param으로 받아오면 jwt 토큰값을 리턴합니다.")
+    @ApiDocumentResponse
+    @RequestMapping(value = "/login ", method = RequestMethod.POST)
+    public String login(
+          @RequestParam("email") String email,
+          @RequestParam("password") String password
+    ){
+        return "JWT토큰";
+    }
+}

--- a/src/main/java/life/inha/icemarket/controller/EmailController.java
+++ b/src/main/java/life/inha/icemarket/controller/EmailController.java
@@ -1,5 +1,8 @@
 package life.inha.icemarket.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import life.inha.icemarket.config.swagger.ApiDocumentResponse;
 import life.inha.icemarket.domain.User;
 import life.inha.icemarket.domain.UserRole;
 import life.inha.icemarket.dto.EmailDto;
@@ -18,6 +21,7 @@ import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @Controller
+@Tag(name="EmailConfirm", description = "이메일 인증 API")
 public class EmailController {
 
     private final UserRepository userRepository;
@@ -25,7 +29,8 @@ public class EmailController {
     private final EmailService emailService;
 
     private String confirm;
-
+    @Operation(description = "회원가입 시 이메일 전송 페이지 - 회원가입 페이지에서 EmailDto를 받아옵니다.")
+    @ApiDocumentResponse
     @GetMapping("/emailconfirm")
     public String emailConfirm(@ModelAttribute("EmailDto") EmailDto emailDto, Model model) throws Exception{
         String email = emailDto.getEmail();
@@ -36,7 +41,8 @@ public class EmailController {
         model.addAttribute("EmailDto",emailDto);
         return "ConfirmEmail";
     }
-
+    @Operation(description = "회원가입 시 이메일 인증 페이지 - EmailDto를 받아옵니다.")
+    @ApiDocumentResponse
     @ResponseBody
     @RequestMapping(
             value="/emailconfirm",

--- a/src/main/java/life/inha/icemarket/controller/SignupController.java
+++ b/src/main/java/life/inha/icemarket/controller/SignupController.java
@@ -41,10 +41,10 @@ public class SignupController {
     )
     public String signup(
             @AuthenticationPrincipal User user,
-            @Valid UserCreateDto userCreateDto, BindingResult bindingResult,
+            @ModelAttribute("UserCreateDto") @Valid UserCreateDto userCreateDto, BindingResult bindingResult,
             RedirectAttributes redirectAttributes) throws Exception{
         if (bindingResult.hasErrors()){
-            return "Binding Result Error" + bindingResult.getObjectName();
+            return "Binding Result Error " + bindingResult.getObjectName();
         }
 
         if (!userCreateDto.getPassword1().equals(userCreateDto.getPassword2())){

--- a/src/main/java/life/inha/icemarket/controller/SignupController.java
+++ b/src/main/java/life/inha/icemarket/controller/SignupController.java
@@ -7,6 +7,7 @@ import life.inha.icemarket.domain.User;
 import life.inha.icemarket.domain.UserRole;
 import life.inha.icemarket.dto.EmailDto;
 import life.inha.icemarket.dto.UserCreateDto;
+import life.inha.icemarket.service.EmailService;
 import life.inha.icemarket.service.UserCreateService;
 import life.inha.icemarket.service.UserRoleService;
 import lombok.AllArgsConstructor;
@@ -32,7 +33,9 @@ import javax.validation.Valid;
 public class SignupController {
 
     private final UserCreateService userCreateService;
+    private final EmailService emailService;
 
+    @ResponseBody
     @Operation(description = "회원가입")
     @ApiDocumentResponse
     @RequestMapping(
@@ -41,8 +44,8 @@ public class SignupController {
     )
     public String signup(
             @AuthenticationPrincipal User user,
-            @ModelAttribute("UserCreateDto") @Valid UserCreateDto userCreateDto, BindingResult bindingResult,
-            RedirectAttributes redirectAttributes) throws Exception{
+            @ModelAttribute("UserCreateDto") @Valid UserCreateDto userCreateDto, BindingResult bindingResult
+            ) throws Exception{
         if (bindingResult.hasErrors()){
             return "Binding Result Error " + bindingResult.getObjectName();
         }
@@ -62,10 +65,7 @@ public class SignupController {
                 UserRole.GUEST
         );
 
-        EmailDto emailDto = new EmailDto();
-        emailDto.setEmail(userCreateDto.getEmail());
-        redirectAttributes.addFlashAttribute("EmailDto", emailDto);
-        return "redirect:/emailconfirm"; //todo redirect
+        return "success"; //todo redirect
     }
     @Operation(description = "회원가입")
     @ApiDocumentResponse

--- a/src/main/java/life/inha/icemarket/controller/SignupController.java
+++ b/src/main/java/life/inha/icemarket/controller/SignupController.java
@@ -23,11 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
-import javax.validation.ValidationException;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+
 
 @Tag(name="Signup", description = "회원가입 API")
 @Slf4j
@@ -71,7 +67,8 @@ public class SignupController {
         redirectAttributes.addFlashAttribute("EmailDto", emailDto);
         return "redirect:/emailconfirm"; //todo redirect
     }
-
+    @Operation(description = "회원가입")
+    @ApiDocumentResponse
     @GetMapping("/signup")
     public String signup(Model model){
         model.addAttribute("UserCreateDto", new UserCreateDto());

--- a/src/main/java/life/inha/icemarket/domain/User.java
+++ b/src/main/java/life/inha/icemarket/domain/User.java
@@ -53,6 +53,8 @@ public class User implements UserDetails {
 
     @Enumerated(EnumType.STRING)
     private Status status = Status.AWAIT;
+
+    private String emailconfirmkey;
     
     @Builder
     public User(Integer id, @NonNull String name, @NonNull String email, String nickname) {

--- a/src/main/java/life/inha/icemarket/service/EmailService.java
+++ b/src/main/java/life/inha/icemarket/service/EmailService.java
@@ -1,5 +1,9 @@
 package life.inha.icemarket.service;
 
+import life.inha.icemarket.domain.User;
+
 public interface EmailService {
     String sendSimpleMessage(String to)throws Exception;
+    String CreateEmailKey(User user) throws Exception;
+    String loadEmailKey(String email) throws Exception;
 }

--- a/src/main/java/life/inha/icemarket/service/EmailServiceImpl.java
+++ b/src/main/java/life/inha/icemarket/service/EmailServiceImpl.java
@@ -1,29 +1,35 @@
 package life.inha.icemarket.service;
 
 
+import life.inha.icemarket.domain.User;
+import life.inha.icemarket.respository.UserRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+import java.util.Random;
 
 @RequiredArgsConstructor
 @Getter
 @Service
 public class EmailServiceImpl implements EmailService{
     private final JavaMailSender javaMailSender;
+    private final UserRepository userRepository;
 
-    private final String emailPW = createKey();
+    private String emailKey;
 
     public MimeMessage createMessage(String to) throws Exception{
+        emailKey = loadEmailKey(to);
         System.out.println("Send to : " + to);
-        System.out.println("Code : " + emailPW);
+        System.out.println("Code : " + emailKey);
         MimeMessage message = javaMailSender.createMimeMessage();
 
         message.addRecipients(Message.RecipientType.TO, to);
@@ -41,16 +47,13 @@ public class EmailServiceImpl implements EmailService{
         msgg+= "<h3 style='color:blue;'>회원가입 인증 코드입니다.</h3>";
         msgg+= "<div style='font-size:130%'>";
         msgg+= "CODE : <strong>";
-        msgg+= emailPW+"</strong><div><br/> ";
+        msgg+= emailKey+"</strong><div><br/> ";
         msgg+= "</div>";
         message.setText(msgg, "utf-8", "html");//내용
 
         message.setFrom(new InternetAddress("imdongle123.gmail.com","ICE-LIFE"));//보내는 사람
 
         return message;
-    }
-    public static String createKey() {
-        return "1234";
     }
 
     @Override
@@ -62,6 +65,29 @@ public class EmailServiceImpl implements EmailService{
            es.printStackTrace();
            throw new IllegalArgumentException();
        }
-       return emailPW;
+       return emailKey;
+    }
+
+    public String CreateEmailKey(User user) throws Exception{
+        int certCharLength=8;
+        char[] characterTable = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+                'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+                'Y', 'Z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' };
+        Random random = new Random(System.currentTimeMillis());
+        int tablelength = characterTable.length;
+        StringBuffer buf = new StringBuffer();
+
+        for(int i=0;i<certCharLength;i++){
+            buf.append(characterTable[random.nextInt(tablelength)]);
+        }
+        String key = buf.toString();
+        user.setEmailconfirmkey(key);
+        userRepository.save(user);
+        return key;
+    }
+
+    public String loadEmailKey(String email) throws Exception{
+        User user = userRepository.findByEmail(email).orElseThrow(()->new UsernameNotFoundException("No user @ EmailServiceImpl"));
+        return user.getEmailconfirmkey();
     }
 }

--- a/src/main/java/life/inha/icemarket/service/UserCreateService.java
+++ b/src/main/java/life/inha/icemarket/service/UserCreateService.java
@@ -35,4 +35,5 @@ public class UserCreateService {
         user.setPasswordHashed(passwordHashed);
         userRepository.save(user);
     }
+
 }

--- a/src/main/java/life/inha/icemarket/service/UserSecurityService.java
+++ b/src/main/java/life/inha/icemarket/service/UserSecurityService.java
@@ -30,9 +30,9 @@ public class UserSecurityService implements UserDetailsService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(()->new UsernameNotFoundException("Can't find user by email @ UserDetails"));
 
-        if(user.getEmail().equals("daezang102@naver.com")){
-            userRoleService.SetUserRole(user,UserRole.ADMIN);
-        }
+//        if(user.getEmail().equals("daezang102@naver.com")){
+//            userRoleService.SetUserRole(user,UserRole.ADMIN);
+//        }
         return user;
     }
 }

--- a/src/test/java/life/inha/icemarket/controller/UserControllerTest.java
+++ b/src/test/java/life/inha/icemarket/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import life.inha.icemarket.domain.User;
+import life.inha.icemarket.dto.UserCreateDto;
 import life.inha.icemarket.respository.UserRepository;
 import life.inha.icemarket.service.UserSecurityService;
 import lombok.extern.slf4j.Slf4j;
@@ -48,7 +49,7 @@ public class UserControllerTest {
     @Autowired
     UserSecurityService userSecurityService;
 
-    private static final String EMAIL = "test@example.com";
+    private static final String EMAIL = "daezang102@naver.com";
 
     private static String createToken(String email){
         if(email == null) email = EMAIL;
@@ -62,22 +63,17 @@ public class UserControllerTest {
     @Test
     @Order(1)
     public void signup() throws Exception {
-        String content = this.objectMapper.writeValueAsString(
-                new SignupController.UserCreateForm(
-                        12340000,
-                        "TestUser",
-                        "password",
-                        "password",
-                        "testuser",
-                        EMAIL
-                )
-        );
+        MultiValueMap<String, String> SignupForm = new LinkedMultiValueMap<>();
+        SignupForm.add("id","12340000");
+        SignupForm.add("name", "TestUser");
+        SignupForm.add("password1","password");
+        SignupForm.add("password2","password");
+        SignupForm.add("nickname","testuser");
+        SignupForm.add("email",EMAIL);
 
         mvc.perform(post("/signup")
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string("success"));
+                        .params(SignupForm))
+                .andExpect(status().is3xxRedirection());
         log.info("Signup Test End");
     }
 
@@ -101,7 +97,7 @@ public class UserControllerTest {
     public void OnlyUserTest() throws Exception {
         mvc.perform(get("/onlyuser")
                         .header("authorization", "Bearer " + createToken(null)))
-                .andExpect(status().is2xxSuccessful());
+                .andExpect(status().is4xxClientError());
         log.info("OnlyUser Test End");
     }
 
@@ -114,6 +110,11 @@ public class UserControllerTest {
         log.info("OnlyAdmin Test End");
     }
 
+    @Test
+    public void EmailConfirmTest() throw Exception{
+        mvc.perform(post("/emailconfirm")
+                .)
+    }
     @Test
     @Order(5)
     public void FindPwGetTest() throws Exception{


### PR DESCRIPTION
- 변경 전 이메일 인증 방식 : form을 이용한 데이터 송신방식
 1. 회원가입이 모두 다 되었다면 SignupController에서 EmailDto와 함께 EmailController의 /api/emailconfirm으로 리다이렉션(=GET요청)을 보냄
 2. get요청을 받은 emailconfirm은 사용자가 emaildto(=form)을 모두 채워주길 기대하고, 그 dto를 /api/emailconfirm으로 POST요청을 보냄.
 3. post요청을 받은 EmailController는 이메일 인증 키가 맞는지 확인하고 권한을 GUEST->USER로 수정해줌.

- 변경 전 이메일 인증 방식의 문제점 : 
 1. 회원가입 이후 사용자가 이메일 인증을 다시 시도할 수 없음. 만약 이메일이 보내지지 않았다거나, 혹은 회원가입 이후 창을 나가버린다면 다시 이메일 인증 창에 도달할 방법이 없음.
 
- 변경 후 이메일 인증 방식 : JWT를 이용한 로그인 방식
 1. 로그인한 사용자만 이메일 인증을 할 수 있음. /api/emailconfirm에 GET요청을 하기 위해서는 @AuthentictationPrincipal, 즉 JWT Bearer Token을 가지고 와야함.
 2. 이 JWT를 이용해 이메일 인증을 하고자 하는 사용자가 누구인지 파악함.
 3. 이 사용자에게 인증코드와 함께 인증코드를 전송함.
 4. 인증코드를 사용자의 이메일로 전송함과 동시에 DB위에 "emailconfirmkey" 컬럼에 인증코드가 업데이트 됨.
 5. 사용자가 이메일 인증 코드를 /api/emailconfirm에 email, JWT와 함께 POST요청을 하면 발급해 준 인증코드와 동일한지 확인 후 권한을 승급해줌.

- 변경 후 이메일 인증 방식의 장점 : 
 1. 사용자가 이메일 인증을 하고싶을 때 할 수 있어, 기존 방식의 문제점을 해결할 수 있다.
 2. 사용자가 이메일 인증을 실패한다거나, 이메일을 받지 못한다거나, 이메일을 재전송하거나, 이메일 인증 코드를 발급받은 이후 홈페이지에 다시 접속해 이메일 인증을 재시도할 경우에도 인증을 할 수 있고, 무엇보다 새로운 인증코드를 발급해 줌으로써 보안을 강화할 수 있다.

- 추가 변경사항 :
 1. 이메일 인증 코드 발급이 기존 "1234" 고정에서 알파벳과 숫자를 조합한 8자리 암호코드로 변경되었음.