### PR TITLE
[Hotfix] 작성자 별명 출력 설정 및 채팅방 초대 신호 전달

### DIFF
--- a/src/main/java/life/inha/icemarket/dto/CommentResDto.java
+++ b/src/main/java/life/inha/icemarket/dto/CommentResDto.java
@@ -5,12 +5,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Data
 @NoArgsConstructor
 public class CommentResDto {
     // 작성자 이름
-    private String author;
+    private String authorNickname;
     // 작성자 학번
     private Integer authorId;
     // 댓글 인덱스 번호
@@ -22,7 +23,7 @@ public class CommentResDto {
 
     public static CommentResDto createCommentRes(Comment comment) {
         CommentResDto newCommentRes = new CommentResDto();
-        newCommentRes.author = comment.getAuthorUser().getName();
+        newCommentRes.authorNickname = Objects.requireNonNullElse(comment.getAuthorUser().getNickname(), comment.getAuthorUser().getName());
         newCommentRes.authorId = comment.getAuthorUser().getId();
         newCommentRes.commentIdx = comment.getId();
         newCommentRes.comment = comment.getContent();

--- a/src/main/java/life/inha/icemarket/dto/PostDto.java
+++ b/src/main/java/life/inha/icemarket/dto/PostDto.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -18,6 +19,7 @@ public class PostDto {
     private Integer id;
     private Integer categoryId;
     private Integer authorId;
+    private String authorNickname;
     private String title;
     private String content;
     private String thumbnail;
@@ -29,6 +31,7 @@ public class PostDto {
                 .id(post.getId())
                 .categoryId(post.getCategory().getId())
                 .authorId(post.getUser().getId())
+                .authorNickname(Objects.requireNonNullElse(post.getUser().getNickname(), post.getUser().getName()))
                 .title(post.getTitle())
                 .content(post.getContent())
                 .thumbnail(post.getThumbnail())


### PR DESCRIPTION
## 1. 작성자 별명 출력 설정

### Post

Post DTO에 `authorNickname` 추가

작성자의 `nickname`을 우선적으로 출력

### Comment

Comment DTO의 `author`를 `authorNickname`으로 수정

작성자의 `nickname`을 우선적으로 출력

## 2. 채팅방 초대 신호 전달

사용자가 초대되면 `/user/${email}/queue/room/join`으로 신호 전달

채팅방 생성 신호와 구독 endpoint를 공유함
